### PR TITLE
make interval constructors explicit

### DIFF
--- a/src/carl/interval/Interval.h
+++ b/src/carl/interval/Interval.h
@@ -186,7 +186,7 @@ namespace carl
          * Constructor which constructs the pointinterval at n.
          * @param n Location of the pointinterval.
          */
-        Interval(const Number& n) :
+        explicit Interval(const Number& n) :
 	        mContent(n),
 	        mLowerBoundType(BoundType::WEAK),
 	        mUpperBoundType(BoundType::WEAK)
@@ -201,7 +201,7 @@ namespace carl
          * @param lower The desired lower bound.
          * @param upper The desired upper bound.
          */
-        Interval(const Number& lower, const Number& upper):
+        explicit Interval(const Number& lower, const Number& upper):
 			mContent(), mLowerBoundType(), mUpperBoundType()
         {
             if (BOUNDS_OK(lower, BoundType::WEAK, upper, BoundType::WEAK))
@@ -351,7 +351,7 @@ namespace carl
          * @param upper The desired upper bound.
          */
         template<typename N = Number, DisableIf<std::is_same<N, double >> = dummy, DisableIf<is_rational<N >> = dummy >
-        Interval(double lower, double upper)
+        explicit Interval(double lower, double upper)
         {
             if (BOUNDS_OK(lower, BoundType::WEAK, upper, BoundType::WEAK))
             {
@@ -433,7 +433,7 @@ namespace carl
          * @param upper The desired upper bound.
          */
         template<typename N = Number, DisableIf<std::is_same<N, int >> = dummy>
-        Interval(int lower, int upper)
+        explicit Interval(int lower, int upper)
         {
             if (BOUNDS_OK(lower, BoundType::WEAK, upper, BoundType::WEAK))
             {
@@ -540,7 +540,7 @@ namespace carl
          * @param upperBoundType The desired upper bound type.
          */
         template<typename N = Number, DisableIf<std::is_same<N, unsigned int >> = dummy>
-        explicit Interval(unsigned int lower, BoundType lowerBoundType, unsigned int upper, BoundType upperBoundType)
+        Interval(unsigned int lower, BoundType lowerBoundType, unsigned int upper, BoundType upperBoundType)
         {
             if (BOUNDS_OK(lower, lowerBoundType, upper, upperBoundType))
             {
@@ -597,7 +597,7 @@ namespace carl
          * @param upper The desired upper bound.
          */
         template<typename Num = Number, typename Rational, EnableIf<std::is_floating_point<Num >> = dummy, DisableIf<std::is_same<Num, Rational >> = dummy>
-        Interval(Rational lower, Rational upper):
+        explicit Interval(Rational lower, Rational upper):
 			mContent(), mLowerBoundType(), mUpperBoundType()
         {
             *this = Interval<double>(lower, BoundType::WEAK, upper, BoundType::WEAK);
@@ -668,7 +668,7 @@ namespace carl
          * @param upper The desired upper bound.
          */
         template<typename Num = Number, typename Float, EnableIf<is_rational<Num >> = dummy, EnableIf<std::is_floating_point<Float >> = dummy, DisableIf<std::is_same<Num, Float >> = dummy>
-        Interval(Float lower, Float upper):
+        explicit Interval(Float lower, Float upper):
 			mContent(), mLowerBoundType(), mUpperBoundType()
         {
             *this = Interval<double>(lower, BoundType::WEAK, upper, BoundType::WEAK);
@@ -738,7 +738,7 @@ namespace carl
          * @param upper The desired upper bound.
          */
         template<typename Num = Number, typename Rational, EnableIf<is_rational<Num >> = dummy, EnableIf<is_rational<Rational >> = dummy, DisableIf<std::is_same<Num, Rational >> = dummy>
-        Interval(Rational lower, Rational upper):
+        explicit Interval(Rational lower, Rational upper):
 			mContent(), mLowerBoundType(), mUpperBoundType()
         {
             *this = Interval<double>(lower, BoundType::WEAK, upper, BoundType::WEAK);

--- a/src/carl/interval/Interval.tpp
+++ b/src/carl/interval/Interval.tpp
@@ -239,21 +239,29 @@ template<typename Number>
 	}
 
     template<typename Number>
-    void Interval<Number>::bloat_by(const Number& width)
-    {
-	if(!isInfinite()){
-	    BoundType lowerTmp = mLowerBoundType;
-	    BoundType upperTmp = mUpperBoundType;
-	    this->set(boost::numeric::widen(mContent, width));
-	    mLowerBoundType = lowerTmp;
-	    mUpperBoundType = upperTmp;
-	} else if (mLowerBoundType != BoundType::INFTY) {
-	    this->set(boost::numeric::widen(mContent, width));
-	    mUpperBoundType = BoundType::INFTY;
-	} else if (mUpperBoundType != BoundType::INFTY) {
-	    this->set(boost::numeric::widen(mContent, width));
+    void Interval<Number>::bloat_by(const Number& width) {
+		if(this->isEmpty()) {
+			return;
+		}
+		if (width == carl::constant_zero<Number>().get()) {
+			mLowerBoundType = BoundType::WEAK;
+			mUpperBoundType = BoundType::WEAK;
+			mContent.assign(0, 0);
+			return;
+		}
+		if (!isInfinite()) {
+			BoundType lowerTmp = mLowerBoundType;
+			BoundType upperTmp = mUpperBoundType;
+			this->set(boost::numeric::widen(mContent, width));
+			mLowerBoundType = lowerTmp;
+			mUpperBoundType = upperTmp;
+		} else if (mLowerBoundType != BoundType::INFTY) {
+			this->set(boost::numeric::widen(mContent, width));
+			mUpperBoundType = BoundType::INFTY;
+		} else if (mUpperBoundType != BoundType::INFTY) {
+			this->set(boost::numeric::widen(mContent, width));
 	    mLowerBoundType = BoundType::INFTY;
-	}
+		}
     }
 
     template<typename Number>

--- a/src/carl/interval/operators.h
+++ b/src/carl/interval/operators.h
@@ -395,10 +395,12 @@ inline Interval<Number> operator*(const Interval<Number>& lhs, const Interval<Nu
  */
 template<typename Number>
 inline Interval<Number> operator*(const Interval<Number>& lhs, const Number& rhs) {
-	if (rhs >= 0) {
+	if (rhs > 0 || lhs.isEmpty()) {
 		return Interval<Number>(lhs.rContent() * rhs, lhs.lowerBoundType(), lhs.upperBoundType());
-	} else {
+	} else if (rhs < 0) {
 		return Interval<Number>(lhs.rContent() * rhs, lhs.upperBoundType(), lhs.lowerBoundType());
+	} else {
+		return Interval<Number>{0};
 	}
 }
 
@@ -433,6 +435,9 @@ inline Interval<Number>& operator*=(Interval<Number>& lhs, const Interval<Number
  */
 template<typename Number>
 inline Interval<Number>& operator*=(Interval<Number>& lhs, const Number& rhs) {
+	if (carl::isZero(rhs) && !lhs.isEmpty()) {
+		return Interval<Number>{0};
+	}
 	lhs.rContent() *= rhs;
 	return lhs;
 }

--- a/src/tests/interval/Test_Interval_rational.cpp
+++ b/src/tests/interval/Test_Interval_rational.cpp
@@ -304,13 +304,36 @@ TYPED_TEST(IntervalRationalTest, abs) {
 	EXPECT_EQ(i5.abs().upperBoundType(), BoundType::STRICT);
 }
 
-TYPED_TEST(IntervalRationalTest, mul_assign)
-{
+TYPED_TEST(IntervalRationalTest, mul_assign) {
 	Interval<TypeParam> i(TypeParam(-1));
 	Interval<TypeParam> j(TypeParam(0), BoundType::INFTY, TypeParam(0), BoundType::STRICT);
 	Interval<TypeParam> res(TypeParam(0), BoundType::STRICT, TypeParam(0), BoundType::INFTY);
 	i *= j;
 	EXPECT_EQ(i, res);
+
+	Interval<TypeParam> k{1, BoundType::STRICT, 2, BoundType::STRICT};
+	Interval<TypeParam> res_k = TypeParam(0) * i;
+	Interval<TypeParam> l{1, BoundType::WEAK, 2, BoundType::STRICT};
+	Interval<TypeParam> res_l = TypeParam(0) * i;
+	Interval<TypeParam> m{1, BoundType::STRICT, 2, BoundType::WEAK};
+	Interval<TypeParam> res_m = TypeParam(0) * i;
+	Interval<TypeParam> n{1, BoundType::WEAK, 2, BoundType::WEAK};
+	Interval<TypeParam> res_n = TypeParam(0) * i;
+	Interval<TypeParam> o{0, BoundType::INFTY, 2, BoundType::STRICT};
+	Interval<TypeParam> res_o = TypeParam(0) * i;
+	Interval<TypeParam> p{1, BoundType::STRICT, 1, BoundType::INFTY};
+	Interval<TypeParam> res_p = TypeParam(0) * i;
+	Interval<TypeParam> q{0, BoundType::INFTY, 0, BoundType::INFTY};
+	Interval<TypeParam> res_q = TypeParam(0) * i;
+
+	Interval<TypeParam> zero{0};
+	EXPECT_EQ(res_k, zero);
+	EXPECT_EQ(res_l, zero);
+	EXPECT_EQ(res_m, zero);
+	EXPECT_EQ(res_n, zero);
+	EXPECT_EQ(res_o, zero);
+	EXPECT_EQ(res_p, zero);
+	EXPECT_EQ(res_q, zero);
 }
 
 TYPED_TEST(IntervalRationalTest, set_is_subset) {


### PR DESCRIPTION
Many one-parameter interval constructors were not explicit, which caused weird behavior due to implicit conversion in other libraries using CArL.