### PR TITLE
(master14) explicit default visibility for pools to enable hidden visibility

### DIFF
--- a/src/carl/core/MonomialPool.h
+++ b/src/carl/core/MonomialPool.h
@@ -18,7 +18,7 @@
 namespace carl{
 
 
-	class MonomialPool : public Singleton<MonomialPool>
+	class __attribute__((visibility("default"))) MonomialPool : public Singleton<MonomialPool>
 	{
 		friend class Singleton<MonomialPool>;
 		friend std::ostream& operator<<(std::ostream& os, const MonomialPool& mp);

--- a/src/carl/core/VariablePool.h
+++ b/src/carl/core/VariablePool.h
@@ -27,7 +27,7 @@ namespace carl
  *
  * All methods that modify the pool, that are getInstance(), getFreshVariable() and setName(), are thread-safe.
  */
-class VariablePool : public Singleton<VariablePool>
+class __attribute__((visibility("default"))) VariablePool : public Singleton<VariablePool>
 {
 friend Singleton<VariablePool>;
 private:

--- a/src/carl/util/Singleton.h
+++ b/src/carl/util/Singleton.h
@@ -23,7 +23,7 @@ namespace carl
  * </ul>
  */
 template<typename T>
-class Singleton
+class __attribute__((visibility("default")))  Singleton
 {
 protected:
 	/**


### PR DESCRIPTION
Hidden visibility is an important feature for python bindings. WIth these little annotations, pycarl builds usuable small binaries that do not require to resort to default visibility. Carl itself is not affected as it remains compiled with default visibility anyways (but this supports future changes to create smaller and easier to optimise binaries). 