### PR TITLE
Adapt to recent changes in the cocoa-repository

### DIFF
--- a/resources/cocoa.cmake
+++ b/resources/cocoa.cmake
@@ -9,7 +9,7 @@ endif()
 
 ExternalProject_Add(
     CoCoALib-EP
-	URL "http://cocoa.dima.unige.it/cocoalib/tgz/CoCoALib-${COCOA_VERSION}.tgz"
+	URL "http://cocoa.dima.unige.it/cocoa/cocoalib/tgz/CoCoALib-${COCOA_VERSION}.tgz"
 	URL_MD5 ${COCOA_TGZHASH}
 	DOWNLOAD_NO_PROGRESS 1
 	BUILD_IN_SOURCE YES


### PR DESCRIPTION
The cooca-lib was recently moved to a subdirectory. The current cmake setup does not work anymore, so we updated the URL.

Co-Authored-By: Laszlo Antal <antal@informatik.rwth-aachen.de>