### PR TITLE
fix bug in interval multiplication

### DIFF
--- a/src/carl/interval/operators.h
+++ b/src/carl/interval/operators.h
@@ -436,7 +436,7 @@ inline Interval<Number>& operator*=(Interval<Number>& lhs, const Interval<Number
 template<typename Number>
 inline Interval<Number>& operator*=(Interval<Number>& lhs, const Number& rhs) {
 	if (carl::isZero(rhs) && !lhs.isEmpty()) {
-		lhs.rContent() = 0;
+		return Interval<Number>{0};
 	}
 	lhs.rContent() *= rhs;
 	return lhs;


### PR DESCRIPTION
Minor bug in multiplication with empty intervals.

Co-Authored-By: Laszlo Antal <antal@informatik.rwth-aachen.de>